### PR TITLE
feat: add receipt number and improve layout for multiple receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Este projeto é um gerador de recibos em PDF a partir de um arquivo CSV. Ele lê
 Abaixo está um exemplo do formato do arquivo CSV que deve ser usado como entrada para o gerador de recibos.
 
 ```csv
-Cliente,CPF_CNPJ,Endereço,Valor,Data do Pagamento,Descrição do Serviço,Data de Emissão,Recebedor,Observações
-João da Silva,123.456.789-00,"Rua Exemplo, 123 - Cidade, Estado","500,00",05/11/2024,"Serviço de consultoria em desenvolvimento
+Número,Cliente,CPF_CNPJ,Endereço,Valor,Data do Pagamento,Descrição do Serviço,Data de Emissão,Recebedor,Observações
+1,João da Silva,123.456.789-00,"Rua Exemplo, 123 - Cidade, Estado","500,00",05/11/2024,"Serviço de consultoria em desenvolvimento
 de software.",05/11/2024,Fulano de Tal,"Pago por meio do Ciclano"
-Maria Oliveira,987.654.321-00,"Av. Central, 456 - Cidade, Estado","750,00",06/11/2024,Serviço de design gráfico para criação de logotipo.,06/11/2024,Fulano de Tal
-Pedro Santos,456.789.123-00,"Travessa das Flores, 789 - Cidade, Estado","300,00",07/11/2024,Serviço de manutenção em sistema de gestão.,07/11/2024,Fulano de Tal
-Ana Costa,321.654.987-00,"Praça das Árvores, 101 - Cidade, Estado","450,00",08/11/2024,Serviço de instalação e configuração de rede.,08/11/2024,Fulano de Tal
-Carlos Pereira,789.123.456-00,"Alameda das Palmeiras, 202 - Cidade, Estado","600,00",09/11/2024,Serviço de revisão e auditoria de processos.,09/11/2024,Fulano de Tal
+2,Maria Oliveira,987.654.321-00,"Av. Central, 456 - Cidade, Estado","750,00",06/11/2024,Serviço de design gráfico para criação de logotipo.,06/11/2024,Fulano de Tal
+3,Pedro Santos,456.789.123-00,"Travessa das Flores, 789 - Cidade, Estado","300,00",07/11/2024,Serviço de manutenção em sistema de gestão.,07/11/2024,Fulano de Tal
+4,Ana Costa,321.654.987-00,"Praça das Árvores, 101 - Cidade, Estado","450,00",08/11/2024,Serviço de instalação e configuração de rede.,08/11/2024,Fulano de Tal
+5,Carlos Pereira,789.123.456-00,"Alameda das Palmeiras, 202 - Cidade, Estado","600,00",09/11/2024,Serviço de revisão e auditoria de processos.,09/11/2024,Fulano de Tal
 ```
 
 ## Dependências

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ poetry run python main.py ./recibos_servicos.csv recibos.pdf
 - `./recibos_servicos.csv`: caminho para o arquivo CSV de entrada com os dados dos recibos.
 - `recibos.pdf`: nome do arquivo PDF de saída que conterá os recibos gerados.
 
+## Executando linter
+
+```bash
+poetry run ruff check
+```
+
 ### Exemplo de PDF (em A4)
 
 <img width="561" alt="image" src="https://github.com/user-attachments/assets/0db0f73b-0b9d-410b-91bc-655cc2f56ce0">

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ Abaixo está um exemplo do formato do arquivo CSV que deve ser usado como entrad
 
 ```csv
 Cliente,CPF_CNPJ,Endereço,Valor,Data do Pagamento,Descrição do Serviço,Data de Emissão,Recebedor,Observações
-João da Silva,123.456.789-00,Rua Exemplo, 123 - Cidade, Estado,500,00,05/11/2024,Serviço de consultoria em desenvolvimento de software.,05/11/2024,Fulano de Tal,Observacao opcional
-Maria Oliveira,987.654.321-00,Av. Central, 456 - Cidade, Estado,750,00,06/11/2024,Serviço de design gráfico para criação de logotipo.,06/11/2024,Fulano de Tal,Observacao opcional
-Pedro Santos,456.789.123-00,Travessa das Flores, 789 - Cidade, Estado,300,00,07/11/2024,Serviço de manutenção em sistema de gestão.,07/11/2024,Fulano de Tal,Observacao opcional
-Ana Costa,321.654.987-00,Praça das Árvores, 101 - Cidade, Estado,450,00,08/11/2024,Serviço de instalação e configuração de rede.,08/11/2024,Fulano de Tal,Observacao opcional
-Carlos Pereira,789.123.456-00,Alameda das Palmeiras, 202 - Cidade, Estado,600,00,09/11/2024,Serviço de revisão e auditoria de processos.,09/11/2024,Fulano de Tal,Observacao opcional
+João da Silva,123.456.789-00,"Rua Exemplo, 123 - Cidade, Estado","500,00",05/11/2024,"Serviço de consultoria em desenvolvimento
+de software.",05/11/2024,Fulano de Tal,"Pago por meio do Ciclano"
+Maria Oliveira,987.654.321-00,"Av. Central, 456 - Cidade, Estado","750,00",06/11/2024,Serviço de design gráfico para criação de logotipo.,06/11/2024,Fulano de Tal
+Pedro Santos,456.789.123-00,"Travessa das Flores, 789 - Cidade, Estado","300,00",07/11/2024,Serviço de manutenção em sistema de gestão.,07/11/2024,Fulano de Tal
+Ana Costa,321.654.987-00,"Praça das Árvores, 101 - Cidade, Estado","450,00",08/11/2024,Serviço de instalação e configuração de rede.,08/11/2024,Fulano de Tal
+Carlos Pereira,789.123.456-00,"Alameda das Palmeiras, 202 - Cidade, Estado","600,00",09/11/2024,Serviço de revisão e auditoria de processos.,09/11/2024,Fulano de Tal
 ```
 
 ## Dependências

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import fire
 from icecream import ic
 
 from pypdfrecibos.data import parse_csv_to_receipts
-from pypdfrecibos.pdf import PDFRecibo
+from pypdfrecibos.pdf import PDFReceipt
 
 
 def generate(csvfilepath, outputfilepath, add_page_number='false'):
@@ -10,16 +10,17 @@ def generate(csvfilepath, outputfilepath, add_page_number='false'):
 
     ic(add_page_number)
 
-    pdf = PDFRecibo(add_page_number=add_page_number.lower().strip() == 'true')
+    pdf = PDFReceipt(add_page_number=add_page_number.lower().strip() == 'true')
 
-    for item in items:
+    for i, item in enumerate(items):
         print(f'Creating receipt for {item.client} - {item.value}')
-        pdf.add_page()
-        pdf.add_recipt(item)
+        if i % 2 == 0:
+            pdf.add_page()
+
+        pdf.add_receipt(item)
 
     # Salva o arquivo
     pdf.output(outputfilepath)
-
 
 if __name__ == '__main__':
   fire.Fire(generate)

--- a/poetry.lock
+++ b/poetry.lock
@@ -278,6 +278,33 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "ruff"
+version = "0.7.4"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.7.4-py3-none-linux_armv6l.whl", hash = "sha256:a4919925e7684a3f18e18243cd6bea7cfb8e968a6eaa8437971f681b7ec51478"},
+    {file = "ruff-0.7.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cfb365c135b830778dda8c04fb7d4280ed0b984e1aec27f574445231e20d6c63"},
+    {file = "ruff-0.7.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:63a569b36bc66fbadec5beaa539dd81e0527cb258b94e29e0531ce41bacc1f20"},
+    {file = "ruff-0.7.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d06218747d361d06fd2fdac734e7fa92df36df93035db3dc2ad7aa9852cb109"},
+    {file = "ruff-0.7.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e0cea28d0944f74ebc33e9f934238f15c758841f9f5edd180b5315c203293452"},
+    {file = "ruff-0.7.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:80094ecd4793c68b2571b128f91754d60f692d64bc0d7272ec9197fdd09bf9ea"},
+    {file = "ruff-0.7.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:997512325c6620d1c4c2b15db49ef59543ef9cd0f4aa8065ec2ae5103cedc7e7"},
+    {file = "ruff-0.7.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00b4cf3a6b5fad6d1a66e7574d78956bbd09abfd6c8a997798f01f5da3d46a05"},
+    {file = "ruff-0.7.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7dbdc7d8274e1422722933d1edddfdc65b4336abf0b16dfcb9dedd6e6a517d06"},
+    {file = "ruff-0.7.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e92dfb5f00eaedb1501b2f906ccabfd67b2355bdf117fea9719fc99ac2145bc"},
+    {file = "ruff-0.7.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3bd726099f277d735dc38900b6a8d6cf070f80828877941983a57bca1cd92172"},
+    {file = "ruff-0.7.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2e32829c429dd081ee5ba39aef436603e5b22335c3d3fff013cd585806a6486a"},
+    {file = "ruff-0.7.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:662a63b4971807623f6f90c1fb664613f67cc182dc4d991471c23c541fee62dd"},
+    {file = "ruff-0.7.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:876f5e09eaae3eb76814c1d3b68879891d6fde4824c015d48e7a7da4cf066a3a"},
+    {file = "ruff-0.7.4-py3-none-win32.whl", hash = "sha256:75c53f54904be42dd52a548728a5b572344b50d9b2873d13a3f8c5e3b91f5cac"},
+    {file = "ruff-0.7.4-py3-none-win_amd64.whl", hash = "sha256:745775c7b39f914238ed1f1b0bebed0b9155a17cd8bc0b08d3c87e4703b990d6"},
+    {file = "ruff-0.7.4-py3-none-win_arm64.whl", hash = "sha256:11bff065102c3ae9d3ea4dc9ecdfe5a5171349cdd0787c1fc64761212fc9cf1f"},
+    {file = "ruff-0.7.4.tar.gz", hash = "sha256:cd12e35031f5af6b9b93715d8c4f40360070b2041f81273d0527683d5708fce2"},
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -305,4 +332,4 @@ tests = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "cc3033375dd61711718b391c4244e4d6c0ca9abbf95729b020330e9e844b36ef"
+content-hash = "8f73b13d6413884d32e54951463e7ad8262678ec9c80f3a71dae1845404db5d8"

--- a/pypdfrecibos/data.py
+++ b/pypdfrecibos/data.py
@@ -13,6 +13,7 @@ def parse_csv_to_receipts(file_path: str) -> List[ServiceReceipt]:
 
         for row in reader:
             receipt = ServiceReceipt(
+                num=int(row.get('Número', '0')),
                 client=row["Cliente"],
                 document=row["CPF_CNPJ"],
                 address=row["Endereço"],

--- a/pypdfrecibos/entities.py
+++ b/pypdfrecibos/entities.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 @dataclass
 class ServiceReceipt:
+    num: int
     client: str
     document: str  # CPF/CNPJ
     address: str

--- a/pypdfrecibos/pdf.py
+++ b/pypdfrecibos/pdf.py
@@ -23,6 +23,10 @@ class PDFReceipt(FPDF):
             self._first_item_in_page = True
 
         self.set_font('Arial', 'B', 12)
+
+        if receipt.num > 0:
+            self._add_receipt_num(receipt)
+
         self.cell(0, 0, 'RECIBO DE SERVIÇO', 0, 1, 'C')
         self.ln(10)
 
@@ -50,6 +54,20 @@ class PDFReceipt(FPDF):
         self._write_item('Assinatura: ', '__________________________________________________', ln=True)
         self._write_item('Nome completo: ', receipt.receiver_name, ln=True)
         self._write_item('Data: ', receipt.issue_date.strftime('%d/%m/%Y'))
+
+    def _add_receipt_num(self, receipt):
+        cur_x = self.get_x()
+        cur_y = self.get_y()
+
+        text = f'N. {receipt.num}'
+        total_text_width = max(self.get_string_width(text) + 5, 20)
+
+        self.set_xy(self._page_width - total_text_width - 10, cur_y - 2)
+        self.set_fill_color(200, 200, 200)
+        self.cell(total_text_width, 10, text, border=0, align='C', fill=True)
+        self.set_fill_color(255, 255, 255)
+
+        self.set_xy(cur_x, cur_y)
 
     def _write_item(self, field, value, field_width=50, val_width=0, ln=False):
         self._field(field, field_width)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ fire = "^0.7.0"
 
 [tool.poetry.group.dev.dependencies]
 icecream = "^2.1.3"
+ruff = "^0.7.4"
 
 [build-system]
 requires = ["poetry-core"]

--- a/recibos_servicos.csv
+++ b/recibos_servicos.csv
@@ -1,7 +1,7 @@
-Cliente,CPF_CNPJ,Endereço,Valor,Data do Pagamento,Descrição do Serviço,Data de Emissão,Recebedor,Observações
-João da Silva,123.456.789-00,"Rua Exemplo, 123 - Cidade, Estado","500,00",05/11/2024,"Serviço de consultoria em desenvolvimento
+Número,Cliente,CPF_CNPJ,Endereço,Valor,Data do Pagamento,Descrição do Serviço,Data de Emissão,Recebedor,Observações
+1,João da Silva,123.456.789-00,"Rua Exemplo, 123 - Cidade, Estado","500,00",05/11/2024,"Serviço de consultoria em desenvolvimento
 de software.",05/11/2024,Fulano de Tal,"Pago por meio do Ciclano"
-Maria Oliveira,987.654.321-00,"Av. Central, 456 - Cidade, Estado","750,00",06/11/2024,Serviço de design gráfico para criação de logotipo.,06/11/2024,Fulano de Tal
-Pedro Santos,456.789.123-00,"Travessa das Flores, 789 - Cidade, Estado","300,00",07/11/2024,Serviço de manutenção em sistema de gestão.,07/11/2024,Fulano de Tal
-Ana Costa,321.654.987-00,"Praça das Árvores, 101 - Cidade, Estado","450,00",08/11/2024,Serviço de instalação e configuração de rede.,08/11/2024,Fulano de Tal
-Carlos Pereira,789.123.456-00,"Alameda das Palmeiras, 202 - Cidade, Estado","600,00",09/11/2024,Serviço de revisão e auditoria de processos.,09/11/2024,Fulano de Tal
+2,Maria Oliveira,987.654.321-00,"Av. Central, 456 - Cidade, Estado","750,00",06/11/2024,Serviço de design gráfico para criação de logotipo.,06/11/2024,Fulano de Tal
+3,Pedro Santos,456.789.123-00,"Travessa das Flores, 789 - Cidade, Estado","300,00",07/11/2024,Serviço de manutenção em sistema de gestão.,07/11/2024,Fulano de Tal
+4,Ana Costa,321.654.987-00,"Praça das Árvores, 101 - Cidade, Estado","450,00",08/11/2024,Serviço de instalação e configuração de rede.,08/11/2024,Fulano de Tal
+5,Carlos Pereira,789.123.456-00,"Alameda das Palmeiras, 202 - Cidade, Estado","600,00",09/11/2024,Serviço de revisão e auditoria de processos.,09/11/2024,Fulano de Tal

--- a/recibos_servicos.csv
+++ b/recibos_servicos.csv
@@ -1,0 +1,7 @@
+Cliente,CPF_CNPJ,Endereço,Valor,Data do Pagamento,Descrição do Serviço,Data de Emissão,Recebedor,Observações
+João da Silva,123.456.789-00,"Rua Exemplo, 123 - Cidade, Estado","500,00",05/11/2024,"Serviço de consultoria em desenvolvimento
+de software.",05/11/2024,Fulano de Tal,"Pago por meio do Ciclano"
+Maria Oliveira,987.654.321-00,"Av. Central, 456 - Cidade, Estado","750,00",06/11/2024,Serviço de design gráfico para criação de logotipo.,06/11/2024,Fulano de Tal
+Pedro Santos,456.789.123-00,"Travessa das Flores, 789 - Cidade, Estado","300,00",07/11/2024,Serviço de manutenção em sistema de gestão.,07/11/2024,Fulano de Tal
+Ana Costa,321.654.987-00,"Praça das Árvores, 101 - Cidade, Estado","450,00",08/11/2024,Serviço de instalação e configuração de rede.,08/11/2024,Fulano de Tal
+Carlos Pereira,789.123.456-00,"Alameda das Palmeiras, 202 - Cidade, Estado","600,00",09/11/2024,Serviço de revisão e auditoria de processos.,09/11/2024,Fulano de Tal


### PR DESCRIPTION
## What was done?
This pull request introduces the following features and improvements:
- Added a receipt number to each generated receipt.
- Enhanced the layout to render two receipts per page.
- Integrated a linter for code quality checks.

## How was it done?
- Modified the `ServiceReceipt` class to include a `num` attribute for the receipt number.
- Updated the CSV input format to include a receipt number as the first column.
- Refactored the PDF generation logic to accommodate the new layout, ensuring that two receipts are printed per page.
- Implemented a linter using `ruff` to maintain code quality.

## How was it tested?
- The changes were tested by generating receipts from a sample CSV file, verifying that the receipt numbers appear correctly and that the layout displays two receipts per page as intended.

---

Generated by [GPT-PR](https://github.com/alissonperez/gpt-pr)